### PR TITLE
Handle case where the hole vertex is south of the containing polygon(…

### DIFF
--- a/core/src/test/java/org/elasticsearch/common/geo/builders/PolygonBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/common/geo/builders/PolygonBuilderTests.java
@@ -20,10 +20,10 @@
 package org.elasticsearch.common.geo.builders;
 
 import com.vividsolutions.jts.geom.Coordinate;
-
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.test.geo.RandomShapeGenerator;
 import org.elasticsearch.test.geo.RandomShapeGenerator.ShapeType;
+import org.locationtech.spatial4j.exception.InvalidShapeException;
 
 import java.io.IOException;
 
@@ -124,4 +124,23 @@ public class PolygonBuilderTests extends AbstractShapeBuilderTestCase<PolygonBui
         assertThat("hole should have been closed via coerce", pb.holes().get(0).coordinates(false).length, equalTo(4));
     }
 
+    public void testHoleThatIsSouthOfPolygon() {
+        InvalidShapeException e = expectThrows(InvalidShapeException.class, () -> {
+            PolygonBuilder pb = new PolygonBuilder(new CoordinatesBuilder().coordinate(4, 3).coordinate(3, 2).coordinate(3, 3).close());
+            pb.hole(new LineStringBuilder(new CoordinatesBuilder().coordinate(4, 2).coordinate(3, 1).coordinate(4, 1).close()));
+            pb.build();
+        });
+
+        assertEquals("Hole lies outside shell at or near point (4.0, 1.0, NaN)", e.getMessage());
+    }
+
+    public void testHoleThatIsNorthOfPolygon() {
+        InvalidShapeException e = expectThrows(InvalidShapeException.class, () -> {
+            PolygonBuilder pb = new PolygonBuilder(new CoordinatesBuilder().coordinate(3, 2).coordinate(4, 1).coordinate(3, 1).close());
+            pb.hole(new LineStringBuilder(new CoordinatesBuilder().coordinate(3, 3).coordinate(4, 2).coordinate(4, 3).close()));
+            pb.build();
+        });
+
+        assertEquals("Hole lies outside shell at or near point (4.0, 3.0, NaN)", e.getMessage());
+    }
 }


### PR DESCRIPTION
…s) (#27685)

Normally the hole is assigned to the component of the first edge to the south
of one of its vertices, but if the chosen hole vertex is south of everything
then the binary search returns -1 yielding an ArrayIndexOutOfBoundsException.
Instead, assign the vertex to the component of the first edge to its north.
Subsequent validation catches the fact that the hole is outside its component.

Fixes #25933

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
